### PR TITLE
feat: use /api/collections/overlay-data endpoint

### DIFF
--- a/packages/backend/src/services/MaintainerrService.ts
+++ b/packages/backend/src/services/MaintainerrService.ts
@@ -27,28 +27,41 @@ export class MaintainerrService {
   }
 
   async getCollections(): Promise<MaintainerrCollection[]> {
-    try {
-      // Try the dedicated overlay-data endpoint first (Maintainerr >= 3.4.0)
-      const { data } = await this.client.get<MaintainerrCollection[]>('/api/collections/overlay-data');
-      this.log.info(`Fetched ${data.length} collection(s) from Maintainerr.`);
-      return data;
-    } catch (err) {
-      // Fall back to the legacy endpoint (Maintainerr <= 3.3.x)
-      if (axios.isAxiosError(err) && err.response?.status === 404) {
-        this.log.info('overlay-data endpoint not available, falling back to /api/collections');
-        try {
-          const { data } = await this.client.get<MaintainerrCollection[]>('/api/collections');
-          this.log.info(`Fetched ${data.length} collection(s) from Maintainerr.`);
-          return data;
-        } catch (fallbackErr) {
-          this.log.error(`Failed to fetch Maintainerr collections: ${fallbackErr}`);
-          throw fallbackErr;
-        }
+  let endpoint = '/api/collections/overlay-data';
+
+  try {
+    // Attempt the primary fetch
+    let response = await this.client.get<MaintainerrCollection[]>(endpoint);
+
+    return this.handleSuccess(response.data);
+
+  } catch (err) {
+    // Check for 404 to trigger fallback
+    if (axios.isAxiosError(err) && err.response?.status === 404) {
+      this.log.info('overlay-data endpoint not available, falling back to /api/collections');
+      endpoint = '/api/collections';
+      
+      try {
+        // Attempt the fallback fetch
+        const fallbackResponse = await this.client.get<MaintainerrCollection[]>(endpoint);
+        return this.handleSuccess(fallbackResponse.data);
+      } catch (fallbackErr) {
+        this.log.error('Failed to fetch Maintainerr collections on fallback endpoint.', fallbackErr);
+        throw fallbackErr;
       }
-      this.log.error(`Failed to fetch Maintainerr collections: ${err}`);
-      throw err;
     }
+
+    // Handle all other errors from the initial fetch
+    this.log.error('Failed to fetch Maintainerr collections.', err);
+    throw err;
   }
+}
+
+// A small helper to keep the success logic DRY
+private handleSuccess(data: MaintainerrCollection[]): MaintainerrCollection[] {
+  this.log.info(`Fetched ${data.length} collection(s) from Maintainerr.`);
+  return data;
+}
 
   async getLibraryCollections(
     libraryId: string | number,

--- a/packages/backend/src/services/MaintainerrService.ts
+++ b/packages/backend/src/services/MaintainerrService.ts
@@ -28,10 +28,23 @@ export class MaintainerrService {
 
   async getCollections(): Promise<MaintainerrCollection[]> {
     try {
-      const { data } = await this.client.get<MaintainerrCollection[]>('/api/collections');
+      // Try the dedicated overlay-data endpoint first (Maintainerr >= 3.4.0)
+      const { data } = await this.client.get<MaintainerrCollection[]>('/api/collections/overlay-data');
       this.log.info(`Fetched ${data.length} collection(s) from Maintainerr.`);
       return data;
     } catch (err) {
+      // Fall back to the legacy endpoint (Maintainerr <= 3.3.x)
+      if (axios.isAxiosError(err) && err.response?.status === 404) {
+        this.log.info('overlay-data endpoint not available, falling back to /api/collections');
+        try {
+          const { data } = await this.client.get<MaintainerrCollection[]>('/api/collections');
+          this.log.info(`Fetched ${data.length} collection(s) from Maintainerr.`);
+          return data;
+        } catch (fallbackErr) {
+          this.log.error(`Failed to fetch Maintainerr collections: ${fallbackErr}`);
+          throw fallbackErr;
+        }
+      }
       this.log.error(`Failed to fetch Maintainerr collections: ${err}`);
       throw err;
     }


### PR DESCRIPTION
**Maintainerr >= 3.4.0** changed `GET /api/collections` to return only 2 preview items per collection. 
The new `/api/collections/overlay-data` endpoint returns the full media list.

Falls back to the legacy endpoint for **Maintainerr <= 3.3.x** compatibility.

**AI Disclosure:** 
This change was developed with assistance from an AI coding assistant (Warp). The root cause analysis comparing Maintainerr 3.3.0 vs 3.4.0 API behaviour and the implementation were AI-assisted. The change was tested manually against a live Maintainerr 3.3.0 and 3.4.0 instances.