### PR TITLE
Support for  Maintainerr v3.4.0

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -42,7 +42,7 @@ jobs:
       # https://github.com/sigstore/cosign-installer
       - name: Install cosign
         if: github.event_name != 'pull_request'
-        uses: sigstore/cosign-installer@v4.1.0
+        uses: sigstore/cosign-installer@v4.1.1
         with:
           cosign-release: "v2.6.0"
 

--- a/maintainerr_days_left.ps1
+++ b/maintainerr_days_left.ps1
@@ -1195,7 +1195,7 @@ function Get-CollectionOrderOverride {
 
 function Process-MediaItems {
 
-    $collectionsUrl = "$MAINTAINERR_URL/api/collections"
+    $collectionsUrl = "$MAINTAINERR_URL/api/collections/overlay-data"
 
     $maxRetries = 3
     $retryCount = 0


### PR DESCRIPTION
**Breaking Change must be running Maintainerr v3.4.0**

For full media processing, the API endpoint changed in Maintainerr v3.4.0

"feat(collections): add overlay data endpoint"